### PR TITLE
Hotfix

### DIFF
--- a/snake/common/bam_mod/bam_mod_snake.py
+++ b/snake/common/bam_mod/bam_mod_snake.py
@@ -570,7 +570,7 @@ rule gatk_second_pass_create_recalibration_table:
         '-R {input.reference} ' +
         '-I {input.bam} ' +
         '{params.known} ' +
-        '-nt {threads} ' +
+        '-nct {threads} ' +
         '-BQSR {input.tab} ' +
         '{params.params} ' +                
         '-o {output.tab}')

--- a/snake/wes/wes_snake.py
+++ b/snake/wes/wes_snake.py
@@ -180,7 +180,7 @@ rule wes:
         #expand(SOMATICSEQOUT + '{type}.{tumorNormalMatching}.somaticseq.dbSNP.cosmic.snpEff.vcf', type = ['snp', 'indel'], tumorNormalMatching = getNormalTumorFiles()),
         #HAPLOTYPECALLEROUT + 'combined_dist.pdf',
         #expand(FACETSOUT + '{tumorNormalMatching}.cn', tumorNormalMatching = getNormalTumorFiles()),
-        expand(VARSCANCNVOUT + '{tumorNormalMatching}.cn.txt', tumorNormalMatching = getNormalTumorFiles()),
+        expand(VARSCANCNVOUT + '{tumorNormalMatching}.copynumber', tumorNormalMatching = getNormalTumorFiles()),
         expand(GATKVARIANTCOMBINEOUT + '{tumorNormalMatching}.combined.dbSNP.cosmic.snpEff.vcf', tumorNormalMatching = getNormalTumorFiles())
     output:
         OUTDIR + 'complete.txt'


### PR DESCRIPTION
BaseRecalibrator was using the option -nt. However, it seems that it is only working with -nct.

https://gatkforums.broadinstitute.org/gatk/discussion/1975/how-can-i-use-parallelism-to-make-gatk-tools-run-faster