### PR TITLE
[FIX] Added appropriate wildcards in the log and in the benchmarking files of two…

### DIFF
--- a/snake/common/clip_trim/clip_trim_snake.py
+++ b/snake/common/clip_trim/clip_trim_snake.py
@@ -112,8 +112,8 @@ rule seqpurge_paired:
         out2 = temp(SEQPURGEOUT + '{sample}/PAIREDEND/{fastq}_R2.fastq.gz'),
         out3 = temp(SEQPURGEOUT + '{sample}/PAIREDEND/ORPHAN/{fastq}.fastq.gz'),
     params:
-        lsfoutfile = SEQPURGEOUT + '/{sample}/PAIREDEND/{fastq}.fastq.gz.lsfout.log',
-        lsferrfile = SEQPURGEOUT + '/{sample}/PAIREDEND/{fastq}.fastq.gz.lsferr.log',
+        lsfoutfile = SEQPURGEOUT + '{sample}/PAIREDEND/{fastq}.fastq.gz.lsfout.log',
+        lsferrfile = SEQPURGEOUT + '{sample}/PAIREDEND/{fastq}.fastq.gz.lsferr.log',
         scratch = config['tools']['seqpurge']['scratch'],
         mem = config['tools']['seqpurge']['mem'],
         time = config['tools']['seqpurge']['time'],
@@ -121,11 +121,11 @@ rule seqpurge_paired:
         a2 = config['tools']['seqpurge']['a2'],
         params = config['tools']['seqpurge']['params']
     benchmark:
-        SEQPURGEOUT + '/{sample}/PAIREDEND/{fastq}.fastq.gz.benchmark'
+        SEQPURGEOUT + '{sample}/PAIREDEND/{fastq}.fastq.gz.benchmark'
     threads:
         config['tools']['seqpurge']['threads']
     log:
-        SEQPURGEOUT + '/{sample}/PAIREDEND/{fastq}.log'
+        SEQPURGEOUT + '{sample}/PAIREDEND/{fastq}.log'
     shell:
         ('{config[tools][seqpurge][call]} ' +
         '-in1 {input.in1} ' +

--- a/snake/common/variants/variant_mod_snake.py
+++ b/snake/common/variants/variant_mod_snake.py
@@ -38,15 +38,15 @@ rule getBamHeader:
     output:
         txt = CREATEREFERENCEHEADERIN + '{tumor}.header.txt'
     params:
-        lsfoutfile = CREATEREFERENCEHEADERIN + '{tumor}.getBamHeader.lsfout.log',
-        lsferrfile = CREATEREFERENCEHEADERIN + '{tumor}.getBamHeader.lsferr.log',
+        lsfoutfile = CREATEREFERENCEHEADERIN + '{tumor}.header.lsfout.log',
+        lsferrfile = CREATEREFERENCEHEADERIN + '{tumor}.header.lsferr.log',
         scratch = config['tools']['samtools']['view']['scratch'],
         mem = config['tools']['samtools']['view']['mem'],
         time = config['tools']['samtools']['view']['time']
     threads:
         config['tools']['samtools']['view']['threads']
     benchmark:
-        CREATEREFERENCEHEADERIN + '{tumor}.getBamHeader.benchmark'
+        CREATEREFERENCEHEADERIN + '{tumor}.header.benchmark'
     shell:
         '{config[tools][samtools][call]} view -H -o {output.txt} {input.bam}'
 
@@ -58,15 +58,15 @@ rule createReferenceHeaderFile:
         #txt = CREATEREFERENCEHEADEROUT + 'referenceNames_forVCFheaderUpdate.txt'
         txt = CREATEREFERENCEHEADEROUT + '{tumor}_vs_{normal}.referenceNames_forVCFheaderUpdate.txt'
     params:
-        lsfoutfile = CREATEREFERENCEHEADEROUT + '{tumor}_vs_{normal}.createReferenceHeaderFile.lsfout.log',
-        lsferrfile = CREATEREFERENCEHEADEROUT + '{tumor}_vs_{normal}.createReferenceHeaderFile.lsferr.log',
+        lsfoutfile = CREATEREFERENCEHEADEROUT + '{tumor}_vs_{normal}.referenceNames_forVCFheaderUpdate.lsfout.log',
+        lsferrfile = CREATEREFERENCEHEADEROUT + '{tumor}_vs_{normal}.referenceNames_forVCFheaderUpdate.lsferr.log',
         scratch = config['tools']['createReferenceHeaderFile']['scratch'],
         mem = config['tools']['createReferenceHeaderFile']['mem'],
         time = config['tools']['createReferenceHeaderFile']['time']
     threads:
         config['tools']['createReferenceHeaderFile']['threads']
     benchmark:
-        CREATEREFERENCEHEADEROUT + '{tumor}_vs_{normal}.createReferenceHeaderFile.benchmark'
+        CREATEREFERENCEHEADEROUT + '{tumor}_vs_{normal}.referenceNames_forVCFheaderUpdate.benchmark'
     shell:
         '{config[tools][createReferenceHeaderFile][call]} {input.samHeader} {output.txt}'
      

--- a/snake/common/variants/variant_mod_snake.py
+++ b/snake/common/variants/variant_mod_snake.py
@@ -38,15 +38,15 @@ rule getBamHeader:
     output:
         txt = CREATEREFERENCEHEADERIN + '{tumor}.header.txt'
     params:
-        lsfoutfile = CREATEREFERENCEHEADERIN + 'getBamHeader.lsfout.log',
-        lsferrfile = CREATEREFERENCEHEADERIN + 'getBamHeader.lsferr.log',
+        lsfoutfile = CREATEREFERENCEHEADERIN + '{tumor}.getBamHeader.lsfout.log',
+        lsferrfile = CREATEREFERENCEHEADERIN + '{tumor}.getBamHeader.lsferr.log',
         scratch = config['tools']['samtools']['view']['scratch'],
         mem = config['tools']['samtools']['view']['mem'],
         time = config['tools']['samtools']['view']['time']
     threads:
         config['tools']['samtools']['view']['threads']
     benchmark:
-        CREATEREFERENCEHEADERIN + 'getBamHeader.benchmark'
+        CREATEREFERENCEHEADERIN + '{tumor}.getBamHeader.benchmark'
     shell:
         '{config[tools][samtools][call]} view -H -o {output.txt} {input.bam}'
 
@@ -58,15 +58,15 @@ rule createReferenceHeaderFile:
         #txt = CREATEREFERENCEHEADEROUT + 'referenceNames_forVCFheaderUpdate.txt'
         txt = CREATEREFERENCEHEADEROUT + '{tumor}_vs_{normal}.referenceNames_forVCFheaderUpdate.txt'
     params:
-        lsfoutfile = CREATEREFERENCEHEADEROUT + 'createReferenceHeaderFile.lsfout.log',
-        lsferrfile = CREATEREFERENCEHEADEROUT + 'createReferenceHeaderFile.lsferr.log',
+        lsfoutfile = CREATEREFERENCEHEADEROUT + '{tumor}_vs_{normal}.createReferenceHeaderFile.lsfout.log',
+        lsferrfile = CREATEREFERENCEHEADEROUT + '{tumor}_vs_{normal}.createReferenceHeaderFile.lsferr.log',
         scratch = config['tools']['createReferenceHeaderFile']['scratch'],
         mem = config['tools']['createReferenceHeaderFile']['mem'],
         time = config['tools']['createReferenceHeaderFile']['time']
     threads:
         config['tools']['createReferenceHeaderFile']['threads']
     benchmark:
-        CREATEREFERENCEHEADEROUT + 'createReferenceHeaderFile.benchmark'
+        CREATEREFERENCEHEADEROUT + '{tumor}_vs_{normal}.createReferenceHeaderFile.benchmark'
     shell:
         '{config[tools][createReferenceHeaderFile][call]} {input.samHeader} {output.txt}'
      


### PR DESCRIPTION
… rules. ( getBamHeader and createReferenceHeaderFile) The newest snakemake version throws an error if they are missing.