### PR TITLE
 [FEATURE] Added Freebayes as a variant caller.

### DIFF
--- a/snake/common/variants/variants_snake.py
+++ b/snake/common/variants/variants_snake.py
@@ -1,11 +1,11 @@
 # Freebayes calls a variant multiple times, when a bed file contains overlapping regions.
 # This rule uses bedtools merge to flatten a bedfile.
 
-rule flattenBedfileFreebayes:
+rule mergeRegionsInBed:
     input:
         regions = config['resources'][ORGANISM]['regions']
     output:
-        flat_bed = FREEBAYESOUT + 'regions.bed'
+        flat_bed = FREEBAYESOUT + '_mergedRegions.bed'
     params:
         lsfoutfile = FREEBAYESOUT + 'regions.lsfout.log',
         lsferrfile = FREEBAYESOUT + 'regions.lsferr.log',
@@ -36,7 +36,7 @@ rule freebayes:
         bam = expand(FREEBAYESIN + '{sample}.bam', sample = SAMPLENAMES),
         bai = expand(FREEBAYESIN + '{sample}.bai', sample = SAMPLENAMES),
         reference = config['resources'][ORGANISM]['reference'],
-        regions_flat = FREEBAYESOUT + 'regions.bed'
+        regions_flat = FREEBAYESOUT + '_mergedRegions.bed'
     output:
         vcf = FREEBAYESOUT + 'all.vcf',
         suc = FREEBAYESOUT + 'freebayes.complete.txt'

--- a/snake/common/variants/variants_snake.py
+++ b/snake/common/variants/variants_snake.py
@@ -1,14 +1,21 @@
 # Freebayes calls a variant multiple times, when a bed file contains overlapping regions.
 # This rule uses bedtools merge to flatten a bedfile.
 
+if not 'FREEBAYESIN' in globals():
+    FREEBAYESIN = BASERECALIBRATIONOUT
+if not 'FREEBAYESOUT' in globals():
+    FREEBAYESOUT = OUTDIR + 'variants/freebayes/raw/'
+if not 'MERGEREGIONSINBEDOUT' in globals():
+    MERGEREGIONSINBEDOUT = FREEBAYESOUT
+
 rule mergeRegionsInBed:
     input:
         regions = config['resources'][ORGANISM]['regions']
     output:
-        flat_bed = FREEBAYESOUT + '_mergedRegions.bed'
+        flat_bed =  config['resources'][ORGANISM]['regions'] + '_mergedRegions.bed'
     params:
-        lsfoutfile = FREEBAYESOUT + 'regions.lsfout.log',
-        lsferrfile = FREEBAYESOUT + 'regions.lsferr.log',
+        lsfoutfile = MERGEREGIONSINBEDOUT + 'regions.lsfout.log',
+        lsferrfile = MERGEREGIONSINBEDOUT + 'regions.lsferr.log',
         scratch = config['tools']['bedtools']['merge']['scratch'],
         mem = config['tools']['bedtools']['merge']['mem'],
         time = config['tools']['bedtools']['merge']['time']
@@ -25,18 +32,13 @@ def getFreebayesFiles():
         names = names + '-b ' + FREEBAYESIN + '/' + w + '.bam '
     return names
 
-if not 'FREEBAYESIN' in globals():
-    FREEBAYESIN = BASERECALIBRATIONOUT
-if not 'FREEBAYESOUT' in globals():
-    FREEBAYESOUT = OUTDIR + 'variants/freebayes/raw/'
-
 # Call Freebayes:
 rule freebayes:
     input:
         bam = expand(FREEBAYESIN + '{sample}.bam', sample = SAMPLENAMES),
         bai = expand(FREEBAYESIN + '{sample}.bai', sample = SAMPLENAMES),
         reference = config['resources'][ORGANISM]['reference'],
-        regions_flat = FREEBAYESOUT + '_mergedRegions.bed'
+        regions_flat =  config['resources'][ORGANISM]['regions'] + '_mergedRegions.bed'
     output:
         vcf = FREEBAYESOUT + 'all.vcf',
         suc = FREEBAYESOUT + 'freebayes.complete.txt'

--- a/snake/common/variants/variants_snake.py
+++ b/snake/common/variants/variants_snake.py
@@ -1,7 +1,7 @@
 # Freebayes calls a variant multiple times, when a bed file contains overlapping regions.
 # This rule uses bedtools merge to flatten a bedfile.
 
-rule flatten_bedfile_freebayes:
+rule flattenBedfileFreebayes:
     input:
         regions = config['resources'][ORGANISM]['regions']
     output:

--- a/snake/common/variants/variants_snake.py
+++ b/snake/common/variants/variants_snake.py
@@ -14,8 +14,8 @@ rule mergeRegionsInBed:
     output:
         flat_bed =  config['resources'][ORGANISM]['regions'] + '_mergedRegions.bed'
     params:
-        lsfoutfile = MERGEREGIONSINBEDOUT + 'regions.lsfout.log',
-        lsferrfile = MERGEREGIONSINBEDOUT + 'regions.lsferr.log',
+        lsfoutfile = config['resources'][ORGANISM]['regions'] + '_mergedRegions.lsfout.log',
+        lsferrfile = config['resources'][ORGANISM]['regions'] + '_mergedRegions.lsferr.log',
         scratch = config['tools']['bedtools']['merge']['scratch'],
         mem = config['tools']['bedtools']['merge']['mem'],
         time = config['tools']['bedtools']['merge']['time']

--- a/snake/common/variants/variants_snake.py
+++ b/snake/common/variants/variants_snake.py
@@ -5,8 +5,6 @@ if not 'FREEBAYESIN' in globals():
     FREEBAYESIN = BASERECALIBRATIONOUT
 if not 'FREEBAYESOUT' in globals():
     FREEBAYESOUT = OUTDIR + 'variants/freebayes/raw/'
-if not 'MERGEREGIONSINBEDOUT' in globals():
-    MERGEREGIONSINBEDOUT = FREEBAYESOUT
 
 rule mergeRegionsInBed:
     input:


### PR DESCRIPTION
Added Freebayes as an additional variant caller.

According to a discussion here (https://groups.google.com/forum/#!topic/freebayes/EU4gZsjClko) freebayes calls variants over regions without flattening them first.
To avoid many duplicated entries in the output vcf an additional helper rule has been added that uses bedtools to produce a "flattened" region file.