### PR TITLE
[FIX] Bug fix in the createreferenceheader rule.

### DIFF
--- a/snake/common/variants/variant_mod_snake.py
+++ b/snake/common/variants/variant_mod_snake.py
@@ -53,7 +53,7 @@ rule createReferenceHeaderFile:
 rule updateVCFHeader:
     input:
         vcf = '{sample}.vcf',
-        txt = CREATEREFERENCEHEADEROUT + '{sample}.referenceNames_forVCFheaderUpdate.txt'
+        txt = '{sample}.referenceNames_forVCFheaderUpdate.txt'
     output:
         vcf = '{sample}_fullHeader.vcf'
     params:


### PR DESCRIPTION
Having the CREATEREFERCEHEADEROUT folder in the input txt file leads to a strange behaviour. Removed the CREATEREFERENCEHEADEROUT folder.